### PR TITLE
Issue #8 Add missing output

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -39,3 +39,9 @@ Parameters:
   MetricsOutputFormat:
     Type: String
     Description: Streams output format (json or otel)
+Outputs:
+  SplunkAWSCloudWatchStreamingMetricsProcessorFunctionArn:
+    Description: The ARN of the SplunkAWSCloudWatchStreamingMetricsProcessor function
+    Value: !GetAtt SplunkAWSCloudWatchStreamingMetricsProcessor.Arn
+    Export:
+      Name: SplunkAWSCloudWatchStreamingMetricsProcessorFunctionArn


### PR DESCRIPTION
This adds an output for the Function ARN allowing this to be consumed by other CloudFormation stacks.