### PR TITLE
Updated Requirements to support Python 3.8+

### DIFF
--- a/SplunkAWSCloudWatchStreamingMetricsProcessor/requirements.txt
+++ b/SplunkAWSCloudWatchStreamingMetricsProcessor/requirements.txt
@@ -1,2 +1,2 @@
-opentelemetry-proto==1.1.0
-protobuf==3.15.8
+opentelemetry-proto==1.27.0
+protobuf==4.25.5


### PR DESCRIPTION
Updated the requirements file to support latest versions of the following, this is to add support for Python 3.8+ due to 3.8 EOL in June 2024.

opentelemetry-proto==1.27.0
protobuf==4.25.5